### PR TITLE
make new pre-shared key functionality optional

### DIFF
--- a/wg_meshconf/database_manager.py
+++ b/wg_meshconf/database_manager.py
@@ -309,7 +309,7 @@ class DatabaseManager:
         # print the constructed table in console
         Console().print(table)
 
-    def genconfig(self, Name: str, output: pathlib.Path):
+    def genconfig(self, Name: str, output: pathlib.Path, psk: bool):
         database = self.read_database()
 
         # check if peer ID is specified
@@ -330,10 +330,11 @@ class DatabaseManager:
             print(f"Creating output directory: {output}", file=sys.stderr)
             output.mkdir(exist_ok=True)
 
-        # generate pre-shared keys for quantum resistance
-        preshared_keys = {}
-        for _combo_pair in itertools.combinations(peers, 2):
-            preshared_keys[json.dumps(sorted(list(_combo_pair)))] = self.wireguard.genpsk()
+        # optionally generate pre-shared keys for quantum secrecy
+        if psk:
+            preshared_keys = {}
+            for _combo_pair in itertools.combinations(peers, 2):
+                preshared_keys[json.dumps(sorted(list(_combo_pair)))] = self.wireguard.genpsk()
 
         # for every peer in the database
         for peer in peers:
@@ -365,12 +366,13 @@ class DatabaseManager:
                         )
                     )
 
-                    # write pre-shared keys
-                    config.write(
-                        "PresharedKey = {}\n".format(
-                            preshared_keys[json.dumps(sorted(list({peer, p})))]
+                    # optionally write pre-shared keys
+                    if psk:
+                        config.write(
+                            "PresharedKey = {}\n".format(
+                                preshared_keys[json.dumps(sorted(list({peer, p})))]
+                            )
                         )
-                    )
 
                     if database["peers"][p].get("Endpoint") is not None:
                         config.write(

--- a/wg_meshconf/wg_meshconf.py
+++ b/wg_meshconf/wg_meshconf.py
@@ -104,7 +104,7 @@ def parse_arguments():
     showpeers = subparsers.add_parser("showpeers")
     showpeers.add_argument(
         "name",
-        help="Name of the peer to query",
+        help="name of the peer to query",
         nargs="?",
     )
     showpeers.add_argument(
@@ -118,7 +118,7 @@ def parse_arguments():
     genconfig = subparsers.add_parser("genconfig")
     genconfig.add_argument(
         "name",
-        help="Name of the peer to generate configuration for, \
+        help="name of the peer to generate configuration for, \
             configuration for all peers are generated if omitted",
         nargs="?",
     )
@@ -128,6 +128,13 @@ def parse_arguments():
         help="configuration file output directory",
         type=pathlib.Path,
         default=pathlib.Path.cwd() / "output",
+    )
+    genconfig.add_argument(
+        "-p",
+        "--psk",
+        help="generate pre-shared key configuration",
+        default=False,
+        action='store_true',
     )
 
     return parser.parse_args()
@@ -190,7 +197,7 @@ def main():
         database_manager.showpeers(args.name, args.verbose)
 
     elif args.command == "genconfig":
-        database_manager.genconfig(args.name, args.output)
+        database_manager.genconfig(args.name, args.output, args.psk)
 
     # if no commands are specified
     else:


### PR DESCRIPTION
* adds `--psk` / `-p` options to `wg-meshconf genconfig` to make the new functionality optional & **disabled by default** to not breaks existing user configuration.

* the new `pre-shared` key functionality does not store the generated keys as storing them in a spreadsheet alongside the private keys defeats the purpose. When using the new `--psk` option the `pre-shared` keys are re-generated (as keys should be rotated periodically)